### PR TITLE
Fix: Correct timer progress bar and translate to English

### DIFF
--- a/src/app/components/KitchenTimer.tsx
+++ b/src/app/components/KitchenTimer.tsx
@@ -51,30 +51,30 @@ const KitchenTimer: React.FC = () => {
 
   return (
     <div className="bg-white p-6 rounded-lg shadow-2xl w-full max-w-md">
-      <h1 className="text-3xl sm:text-4xl font-bold text-center text-gray-800 mb-6">厨房倒计时</h1>
+      <h1 className="text-3xl sm:text-4xl font-bold text-center text-gray-800 mb-6">Kitchen Timer</h1>
       <div className="w-full h-40 bg-gray-100 rounded-lg flex items-center justify-center mb-4">
         <div className={`text-6xl sm:text-7xl font-bold text-center font-mono transition-colors duration-300 ${getColorClass()}`}>
           {formatTime(time)}
         </div>
       </div>
-      <div className="w-full h-2 bg-blue-500 rounded-full mb-6 overflow-hidden">
+      <div className="w-full h-2 bg-gray-200 rounded-full mb-6 overflow-hidden">
         <div 
-          className="h-full bg-gray-200 rounded-full transition-all duration-300 ease-linear"
-          style={{ width: `${100 - (time / totalTime) * 100}%`, marginLeft: 'auto' }}
+          className="h-full bg-blue-500 rounded-full transition-all duration-300 ease-linear"
+          style={{ width: totalTime > 0 ? `${(time / totalTime) * 100}%` : '0%' }}
         ></div>
       </div>
       <div className="grid grid-cols-2 gap-4">
         <button onClick={() => startTimer(60)} className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-4 px-4 rounded-full transition duration-300 text-lg">
-          1分钟
+          1 Minute
         </button>
         <button onClick={() => startTimer(180)} className="bg-green-500 hover:bg-green-600 text-white font-bold py-4 px-4 rounded-full transition duration-300 text-lg">
-          3分钟
+          3 Minutes
         </button>
         <button onClick={() => startTimer(300)} className="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-4 px-4 rounded-full transition duration-300 text-lg">
-          5分钟
+          5 Minutes
         </button>
         <button onClick={stopTimer} className="bg-red-500 hover:bg-red-600 text-white font-bold py-4 px-4 rounded-full transition duration-300 text-lg">
-          停止
+          Stop
         </button>
       </div>
       <audio ref={audioRef} src="/alarm.mp3" />


### PR DESCRIPTION
- I fixed the progress bar in KitchenTimer.tsx to accurately display remaining time, visually depleting from right to left.
- I translated all Chinese text in KitchenTimer.tsx (heading and button labels) to English.
- I noted that `alarm.mp3` is required in the `public` directory for sound notifications (file not included in this commit).